### PR TITLE
Log results as strings instead of []byte

### DIFF
--- a/logging.go
+++ b/logging.go
@@ -45,7 +45,7 @@ func (s *loggingService) Exec(ctx context.Context, req GraphqlRequest) (res *gra
 			"query", req.Query,
 			"took", time.Since(begin),
 			"error", err,
-			"response", responseJSON,
+			"response", string(responseJSON),
 		)
 	}(time.Now())
 	res = s.Service.Exec(ctx, req)

--- a/service.go
+++ b/service.go
@@ -32,6 +32,6 @@ func getGraphqlSchema(schema string, res interface{}) *graphql.Schema {
 	if err != nil {
 		panic(err)
 	}
-	opts := []graphql.SchemaOpt{graphql.UseFieldResolvers()}
+	opts := []graphql.SchemaOpt{graphql.UseFieldResolvers(), graphql.UseStringDescriptions()}
 	return graphql.MustParseSchema(string(schemaFile), res, opts...)
 }


### PR DESCRIPTION
Hence avoiding the conversion to base64 by the logger